### PR TITLE
보안을 위한 Access/Refresh 토큰 저장 위치

### DIFF
--- a/backend/src/main/java/com/example/oauthjwt/jwt/JWTUtil.java
+++ b/backend/src/main/java/com/example/oauthjwt/jwt/JWTUtil.java
@@ -22,8 +22,8 @@ public class JWTUtil {
 
   public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
     secretKey =
-        new SecretKeySpec(
-            secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+            new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
   }
 
   public String getUsername(String token) {
@@ -41,42 +41,32 @@ public class JWTUtil {
 
   public String getRole(String token) {
     return Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getPayload()
-        .get("role", String.class);
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("role", String.class);
   }
 
   public Boolean isExpired(String token) {
     return Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getPayload()
-        .getExpiration()
-        .before(new Date());
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getExpiration()
+            .before(new Date());
   }
 
   public String createJwt(String username, String role, Long expiredMs) {
 
     return Jwts.builder()
-        .claim("username", username)
-        .claim("role", role)
-        .issuedAt(new Date(System.currentTimeMillis()))
-        .expiration(new Date(System.currentTimeMillis() + expiredMs))
-        .signWith(secretKey)
-        .compact();
-  }
-
-  public String getTokenFromCookies(HttpServletRequest request) {
-    Cookie[] cookies = request.getCookies();
-    if (cookies == null) return null;
-    return Arrays.stream(cookies)
-            .filter(cookie -> "Authorization".equals(cookie.getName()))
-            .map(Cookie::getValue)
-            .findFirst()
-            .orElse(null);
+            .claim("username", username)
+            .claim("role", role)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + expiredMs))
+            .signWith(secretKey)
+            .compact();
   }
 
   public String getTokenFromCookiesByName(HttpServletRequest request, String name) {

--- a/backend/src/main/java/com/example/oauthjwt/oauth2/CustomSuccessHandler.java
+++ b/backend/src/main/java/com/example/oauthjwt/oauth2/CustomSuccessHandler.java
@@ -17,6 +17,13 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * ✅ 리팩토링 포인트:
+ * - Access Token은 바디와 localStorage로 관리 (쿠키 X)
+ * - Refresh Token은 HttpOnly 쿠키로만 발급
+ * - /refresh에서 Refresh Token은 재발급하지 않음
+ * ✅ 적용된 파일: AuthController, CustomSuccessHandler
+ * */
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
@@ -29,8 +36,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
   @Override
   public void onAuthenticationSuccess(
-      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
-      throws IOException, ServletException {
+          HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+          throws IOException, ServletException {
 
     // OAuth2User
     CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
@@ -43,12 +50,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     String role = auth.getAuthority();
 
     // JWT 토큰 생성
-    // String token = jwtUtil.createJwt(username, role, 60 * 60 * 60L); // 1일
     String accessToken = jwtUtil.createJwt(username, role, 15 * 60 * 1000L); // 15분
     String refreshToken = jwtUtil.createRefreshToken(username, 7 * 24 * 60 * 60 * 1000L); // 7일
     // JWT 토큰을 쿠키로 전달
-    // response.addCookie(createCookie("Authorization", token));
-    response.addCookie(createCookie("Authorization", accessToken));
+//    response.addCookie(createCookie("Authorization", accessToken)); // LocalStorage에 저장
     response.addCookie(createCookie("Refresh", refreshToken));
     response.sendRedirect("http://localhost:5173/");
   }

--- a/client-app/src/state/Api.js
+++ b/client-app/src/state/Api.js
@@ -1,5 +1,4 @@
 // Api.js
-
 import axios from "axios";
 
 const api = axios.create({
@@ -7,17 +6,24 @@ const api = axios.create({
   withCredentials: true, // 쿠키 포함
 });
 
+// ✅ 요청 인터셉터: Access 토큰 헤더에 자동 주입
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 /**
  * 토큰 리프레시 요청을 위한 인터셉터 설정
  * - Access Token 만료 시 Refresh Token을 사용하여 새로운 Access Token을 발급받음
  */
-// ✅ 응답 인터셉터 설정
+// ✅ 응답 인터셉터 설정: Access 토큰 만료 시 Refresh
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-
-    // Access Token 만료 → Refresh 시도
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
@@ -25,23 +31,16 @@ api.interceptors.response.use(
     ) {
       originalRequest._retry = true;
       try {
-        await axios.post(
-          "http://localhost:8282/api/auth/refresh",
-          {},
-          {
-            withCredentials: true,
-          }
-        );
-
-        // 재요청
+        const refreshRes = await api.post("/api/auth/refresh", {});
+        const newAccessToken = refreshRes.data.accessToken;
+        localStorage.setItem("accessToken", newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return api(originalRequest);
       } catch (refreshError) {
-        console.error("❌ Refresh 토큰도 실패:", refreshError);
-        // 필요 시 로그아웃 처리도 가능
+        console.error("❌ Refresh 토큰 실패:", refreshError);
         return Promise.reject(refreshError);
       }
     }
-
     return Promise.reject(error);
   }
 );

--- a/client-app/src/state/auth/Action.js
+++ b/client-app/src/state/auth/Action.js
@@ -1,16 +1,15 @@
-// src/auth/Action.js
+//Action.js
+
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import api from "../Api";
 
-// 이메일 로그인 액션
+// ✅ 로그인
 export const loginUser = createAsyncThunk(
   "auth/loginUser",
   async ({ email, password }, { rejectWithValue }) => {
     try {
-      const response = await api.post("/api/auth/login", {
-        email,
-        password,
-      });
+      const response = await api.post("/api/auth/login", { email, password });
+      localStorage.setItem("accessToken", response.data.accessToken); // ✅ localStorage 저장
       return response.data;
     } catch (error) {
       return rejectWithValue(error.response?.data || "로그인 실패");
@@ -18,12 +17,13 @@ export const loginUser = createAsyncThunk(
   }
 );
 
-// 로그아웃 액션
+// ✅ 로그아웃
 export const logoutUser = createAsyncThunk(
   "auth/logoutUser",
   async (_, { rejectWithValue }) => {
     try {
       const response = await api.post("/api/auth/logout", {});
+      localStorage.removeItem("accessToken"); // ✅ localStorage 삭제
       return response.data;
     } catch (error) {
       return rejectWithValue(error.response?.data || "로그아웃 실패");
@@ -31,7 +31,7 @@ export const logoutUser = createAsyncThunk(
   }
 );
 
-// 사용자 정보 조회 액션
+// ✅ 사용자 정보 조회
 export const fetchUser = createAsyncThunk(
   "auth/fetchUser",
   async (_, { rejectWithValue }) => {


### PR DESCRIPTION
Access/Refresh 토큰을 다른 방식으로 저장하는 경우,
이 브랜치의 스프링 시큐리티 코드를 사용 할 수 있습니다.
그런 경우를 위해, 해당 브랜치와 Pull Request를 보관 하도록 하겠습니다.

# Title
- 출처: 개발자 유미 블로그 https://www.devyummi.com/page?id=669514be59f57d23e8a0b6a9
- Access 토큰 : 권한이 필요한 모든 요청 헤더에 사용될 JWT로 탈취 위험을 낮추기 위해 약 10분 정도의 짧은 생명주기를 가진다.
- Refresh 토큰 : Access 토큰이 만료되었을 때 재발급 받기 위한 용도로만 사용되며 약 24시간 이상의 긴 생명주기를 가진다.

## Key Changes

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## Test method(스크린샷 추가)
- Access : 헤더에 발급 후 프론트에서 로컬 스토리지 저장
![image](https://github.com/user-attachments/assets/281ef2af-c5fe-4287-ab05-506a2e7f55bc)
- Refresh : 쿠키에 발급
![image](https://github.com/user-attachments/assets/1ce0850e-7dd6-4831-9bb0-a43b8b93da25)

- 설명 추가

## PR Checklist

- [ ] ./gradlew spotlessApply
- [ ] npx prettier --write "**/\*.html" "**/_.js" "\*\*/_.css"
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
